### PR TITLE
automate setting allowed_ip for easy demo setup

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,7 @@
+data "http" "myip" {
+  url = "http://ipv4.icanhazip.com"
+}
+
+locals {
+    allowed_ip = "${chomp(data.http.myip.body)}/32"
+}

--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,7 @@ resource "aws_security_group" "swarm" {
     from_port   = 0
     to_port     = 0
     protocol    = -1
-    cidr_blocks = [var.allowed_ip]
+    cidr_blocks = [local.allowed_ip]
   }
 
   ingress {
@@ -174,7 +174,7 @@ resource "aws_security_group" "swarm" {
     from_port   = 0
     to_port     = 0
     protocol    = -1
-    cidr_blocks = [var.allowed_ip]
+    cidr_blocks = [local.allowed_ip]
   }
 
   egress {

--- a/network.tf
+++ b/network.tf
@@ -174,7 +174,7 @@ resource "aws_vpc_endpoint" "secretsmanager" {
 #   egress         = false
 #   protocol       = "tcp"
 #   rule_action    = "allow"
-#   cidr_block     = var.allowed_ip
+#   cidr_block     = local.allowed_ip
 #   from_port      = 8080
 #   to_port        = 8080
 # }
@@ -284,7 +284,7 @@ resource "aws_vpc_endpoint" "secretsmanager" {
 #   egress         = false
 #   protocol       = "tcp"
 #   rule_action    = "allow"
-#   cidr_block     = var.allowed_ip
+#   cidr_block     = local.allowed_ip
 #   from_port      = 22
 #   to_port        = 22
 # }


### PR DESCRIPTION
this grab the ip of the user that is running terraform and sets a local allowed_ip variable

might be a security risk, but this feature could be shut off by default with a flag if you want