### PR TITLE
fixes an interpolation issue when has_pem uses the default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -20,8 +20,8 @@ variable "aws_key_name" {
 # allows ssh between instances if desired
 variable has_pem {
   description = "1 if passing a pem for containers to ssh back and forth"
-  type        = string
-  default     = ""
+  type        = bool
+  default     = false
 }
 variable "allowed_ip" {
   description = "Ip to allow ssh access ie. 173.2.2.2/32"


### PR DESCRIPTION
```
Error: Incorrect condition type

  on s3_bucket.tf line 43, in resource "aws_s3_bucket_object" "file_upload":
  43:   count  = var.has_pem ? 1 : 0
    |----------------
    | var.has_pem is ""

The condition expression must be of type bool.
```